### PR TITLE
Include qcommon.h for declaration of Cvar_SetValue

### DIFF
--- a/source/game/g_unlagged.c
+++ b/source/game/g_unlagged.c
@@ -22,6 +22,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #endif
 
 #include "g_local.h"
+#include "qcommon/qcommon.h"
 
 /*
 ============


### PR DESCRIPTION
alienarena 7.71.6 fails to build with modern clang compilers (Apple clang 12 or later or llvm.org clang 16 or later) because they consider implicit function declarations to be an error:

```
game/g_unlagged.c:169:4: error: call to undeclared function 'Cvar_SetValue'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  169 |                         Cvar_SetValue("g_antilagprojectiles", 0);
      |                         ^
1 error generated.
```

The fix is to `#include "qcommon/qcommon.h"` in source/game/g_unlagged.c.